### PR TITLE
Fix release workflow force-push to main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
         id: reset_main
         run: |
           echo ${{ github.ref }} 
-          /usr/bin/git push origin ${{ github.ref }}:main
+          /usr/bin/git push --force origin ${{ github.ref }}:main
       - name: Generate changelog
         id: changelog
         uses: metcalfc/changelog-generator@0440d0932f9a0dd1cc9ecd8412830761351323bd # v4.7.0


### PR DESCRIPTION
## Summary
- Release failed for `v1.9.0` because PR #137 merged to `main` directly, so `main` and the staging tag diverged
- The release workflow resets `main` to the tag (documented behavior) but was missing `--force`
- The workflow PAT should bypass branch protection (local force-push is blocked)

## After merge
1. Delete and re-create tag `v1.9.0` on the new staging tip to re-trigger release:
   ```bash
   git checkout staging && git pull
   git push origin :refs/tags/v1.9.0
   git tag -f v1.9.0
   git push origin v1.9.0
   ```

## Test plan
- [ ] Merge this PR
- [ ] Re-tag `v1.9.0` and confirm release workflow completes

Made with [Cursor](https://cursor.com)